### PR TITLE
Correcting repository URL

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "description": "A timepicker component for Twitter Bootstrap 2.x",
     "repository": {
       "type": "git",
-      "url": "https://github.com/jdewit/bootstrap-timepicker"
+      "url": "https://github.com/nholling/bootstrap-3-timepicker"
     },
     "main": ["js/bootstrap-timepicker.min.js", "css/bootstrap-timepicker.min.css"],
     "dependencies": {


### PR DESCRIPTION
When installing this package via bower, it ends up installing the code in jdewit's repo which doesn't work with Bootstrap 3.
